### PR TITLE
Add new readme for newscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,35 +18,31 @@
 <table>
 <tr><td>
 
-| Key    | Hex       | Sample                             |
-|--------|-----------|------------------------------------|
-| Base00 | `#2B213C` | ![](../images/base00.png?raw=true) |
-| Base01 | `#362C48` | ![](../images/base01.png?raw=true) |
-| Base02 | `#716585` | ![](../images/base02.png?raw=true) |
-| Base03 | `#7E7292` | ![](../images/base03.png?raw=true) |
-| Base04 | `#988BAD` | ![](../images/base04.png?raw=true) |
-| Base05 | `#A598BB` | ![](../images/base05.png?raw=true) |
-| Base06 | `#F1E2FF` | ![](../images/base06.png?raw=true) |
-| Base07 | `#FCEEFF` | ![](../images/base07.png?raw=true) |
+| Key    | Hex       | Sample                                                                         |
+|--------|-----------|--------------------------------------------------------------------------------|
+| Base00 | `#2B213C` | <img src="../images/base00.png?raw=true" alt="base00" width="192" height="66"> |
+| Base01 | `#362B48` | <img src="../images/base01.png?raw=true" alt="base01" width="192" height="66"> |
+| Base02 | `#4D4160` | <img src="../images/base02.png?raw=true" alt="base02" width="192" height="66"> |
+| Base03 | `#655978` | <img src="../images/base03.png?raw=true" alt="base03" width="192" height="66"> |
+| Base04 | `#7F7192` | <img src="../images/base04.png?raw=true" alt="base04" width="192" height="66"> |
+| Base05 | `#998BAD` | <img src="../images/base05.png?raw=true" alt="base05" width="192" height="66"> |
+| Base06 | `#B4A5C8` | <img src="../images/base06.png?raw=true" alt="base06" width="192" height="66"> |
+| Base07 | `#C594FF` | <img src="../images/base07.png?raw=true" alt="base07" width="192" height="66"> |
 
 </td><td>
 
-| Key    | Hex       | Sample                             |
-|--------|-----------|------------------------------------|
-| Base08 | `#BAAD84` | ![](../images/base08.png?raw=true) |
-| Base09 | `#9DBA84` | ![](../images/base09.png?raw=true) |
-| Base0A | `#BA9184` | ![](../images/base0A.png?raw=true) |
-| Base0B | `#8DBAAF` | ![](../images/base0B.png?raw=true) |
-| Base0C | `#A49FD1` | ![](../images/base0C.png?raw=true) |
-| Base0D | `#8865C6` | ![](../images/base0D.png?raw=true) |
-| Base0E | `#BF9FD1` | ![](../images/base0E.png?raw=true) |
-| Base0F | `#BAB884` | ![](../images/base0F.png?raw=true) |
+| Key    | Hex       | Sample                                                                         |
+|--------|-----------|--------------------------------------------------------------------------------|
+| Base08 | `#B5ADDE` | <img src="../images/base08.png?raw=true" alt="base08" width="192" height="66"> |
+| Base09 | `#A5AAD4` | <img src="../images/base09.png?raw=true" alt="base09" width="192" height="66"> |
+| Base10 | `#9BA0C7` | <img src="../images/base10.png?raw=true" alt="base10" width="192" height="66"> |
+| Base11 | `#C79987` | <img src="../images/base11.png?raw=true" alt="base11" width="192" height="66"> |
+| Base12 | `#C7AB87` | <img src="../images/base12.png?raw=true" alt="base12" width="192" height="66"> |
+| Base13 | `#C7C691` | <img src="../images/base13.png?raw=true" alt="base13" width="192" height="66"> |
+| Base14 | `#ACC79B` | <img src="../images/base14.png?raw=true" alt="base14" width="192" height="66"> |
+| Base15 | `#9BC7BF` | <img src="../images/base15.png?raw=true" alt="base15" width="192" height="66"> |
 
 </td></tr> </table>
-
-
-
-
 
 
 ## Installation


### PR DESCRIPTION
Updates readme to match the [`newscheme`](https://github.com/Shrimpram/vim-stella/tree/newscheme) as well as the [new images](https://github.com/Shrimpram/vim-stella/pull/7)